### PR TITLE
Fix keys on Medion Akoya P6669

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1112,6 +1112,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnMAXDATA:pnPro*7000*:pvr*
 # Akoya
 evdev:atkbd:dmi:bvn*:bvr*:svnMEDION*:pnS3409*:pvr*
 evdev:atkbd:dmi:bvn*:bvr*:svnMedion*:pnAkoya*:pvr*
+evdev:atkbd:dmi:bvn*:bvr*:svnMedion*:pnP6669*:pvr*
  KEYBOARD_KEY_a0=!mute
  KEYBOARD_KEY_ae=!volumedown
  KEYBOARD_KEY_b0=!volumeup


### PR DESCRIPTION
My laptop is a Medion Akoya device, but it's ID is `...svnMedion:pnP6669MD60489:pvr...`. It requires the corrections for the Akoya devices. Therefore I added it as the wild card `P6669*` to the `60-keyboard.hwdb` file.